### PR TITLE
Abbreviate climber names in UI labels; show real avatar photos

### DIFF
--- a/src/components/climbing/ClimberAnalysis.vue
+++ b/src/components/climbing/ClimberAnalysis.vue
@@ -3,6 +3,7 @@ import { ref, onUpdated } from 'vue'
 import Aggregate from '@/utils/Aggregate'
 import { useClimberAnalysisStore } from '@/stores/useClimberAnalysisStore'
 import { defaultChartOpts } from '@/utils/ClimbingCharts'
+import { formatClimberName } from '@/utils/Utils'
 import type { ProcessedAscent } from '@/utils/Utils'
 import ChartHandler from '@/components/climbing/charts/ChartHandler.vue'
 import TimeSeriesChart from '@/components/climbing/charts/TimeSeriesChart.vue'
@@ -117,7 +118,7 @@ setTimeout(() => {
 
 <template>
   <div id="climber-analysis">
-    <h1>{{ climberName }}'s Analysis</h1>
+    <h1>{{ formatClimberName(climberName) }}'s Analysis</h1>
     <div v-if="loading">
       <LoadingSpinner :size="64" />
       <div>Analyzing...</div>

--- a/src/components/climbing/ClimberSelect.vue
+++ b/src/components/climbing/ClimberSelect.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { formatClimberName } from '@/utils/Utils'
 import { useClimberManifestStore } from '@/stores/useClimberManifestStore'
 
 defineProps<{
@@ -45,7 +46,7 @@ function navigate(fullPath: string) {
           v-for="climber in manifestStore.sortedClimbers"
           :key="climber.userSlug"
         >
-          {{ climber.userName }}
+          {{ formatClimberName(climber.userName) }}
         </li>
         <li v-if="linkToJsonAnalysis">...</li>
         <li

--- a/src/components/climbing/cookies/ClimberAvatar.vue
+++ b/src/components/climbing/cookies/ClimberAvatar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { getDistinctColor } from '@/utils/Utils'
+import { computed, ref, watch } from 'vue'
+import { formatClimberName, getDistinctColor } from '@/utils/Utils'
 import { useClimberManifestStore } from '@/stores/useClimberManifestStore'
 
 const props = withDefaults(
@@ -17,13 +17,30 @@ const manifestStore = useClimberManifestStore()
 // that doesn't guarantee that ordering.
 manifestStore.fetchAll()
 
-// Deterministic placeholder avatar: initials + a color from the same
-// distinct-color palette used for chart series, keyed by the climber's
-// index in the manifest's stable (hide-independent) slug order so a
-// climber's color stays consistent across this page and any chart that also
-// colors by climber. Deliberately not using the real userAvatar CDN photo
-// URLs present in the raw 8a.nu export - climber names in this app are
-// already pseudonymized, and a real photo would undo that.
+const displayName = computed(() => formatClimberName(props.name))
+
+// Real 8a.nu profile photo, when the climber has set one - falls back to
+// the initials circle below for climbers still on 8a.nu's generic default
+// photo, or if the real photo URL fails to load.
+const manifestEntry = computed(() => manifestStore.findByUserName(props.name))
+const imgFailed = ref(false)
+watch(
+  () => props.name,
+  () => {
+    imgFailed.value = false
+  },
+)
+const avatarUrl = computed(() => {
+  const url = manifestEntry.value?.userAvatar
+  if (!url || url.includes('avatar_default.png') || imgFailed.value) return null
+  return url
+})
+
+// Placeholder avatar (used when there's no real photo): initials + a color
+// from the same distinct-color palette used for chart series, keyed by the
+// climber's index in the manifest's stable (hide-independent) slug order so
+// a climber's color stays consistent across this page and any chart that
+// also colors by climber.
 const initials = computed(() => {
   const parts = props.name.trim().split(/\s+/).filter(Boolean)
   if (parts.length === 0) return '?'
@@ -44,7 +61,17 @@ const color = computed(() => {
 </script>
 
 <template>
+  <img
+    v-if="avatarUrl"
+    class="climber-avatar-img"
+    :src="avatarUrl"
+    :alt="displayName"
+    :title="displayName"
+    :style="{ width: size + 'px', height: size + 'px' }"
+    @error="imgFailed = true"
+  />
   <div
+    v-else
     class="climber-avatar"
     :style="{
       width: size + 'px',
@@ -52,7 +79,7 @@ const color = computed(() => {
       backgroundColor: color,
       fontSize: Math.round(size * 0.4) + 'px',
     }"
-    :title="name"
+    :title="displayName"
   >
     {{ initials }}
   </div>
@@ -69,5 +96,10 @@ const color = computed(() => {
   flex-shrink: 0;
   user-select: none;
   text-shadow: 0 0 2px rgba(0, 0, 0, 0.4);
+}
+.climber-avatar-img {
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/climbing/cookies/ClimberDetailModal.vue
+++ b/src/components/climbing/cookies/ClimberDetailModal.vue
@@ -5,7 +5,7 @@ import DataTable from '@/components/shared/DataTable.vue'
 import ClimberAvatar from './ClimberAvatar.vue'
 import { climberSendHistory, isSendActive } from '@/utils/Cookies'
 import type { CookieSend } from '@/utils/Cookies'
-import { mapGrade } from '@/utils/Utils'
+import { formatClimberName, mapGrade } from '@/utils/Utils'
 
 const props = defineProps<{
   climber: string
@@ -80,7 +80,7 @@ const customSorting: Record<string, (ascending: boolean) => (a: CookieRow, b: Co
       <div class="detail-header">
         <ClimberAvatar :name="climber" :size="48" />
         <div>
-          <h2>{{ climber }}</h2>
+          <h2>{{ formatClimberName(climber) }}</h2>
           <div v-if="currentLevel !== undefined" class="current-level">
             Current Level: V{{ currentLevel }}
           </div>

--- a/src/components/climbing/cookies/CookieCalendar.vue
+++ b/src/components/climbing/cookies/CookieCalendar.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import ClimberAvatar from './ClimberAvatar.vue'
 import type { MonthlyWinner } from '@/utils/Cookies'
-import { mapName } from '@/utils/Utils'
+import { formatClimberName, mapName } from '@/utils/Utils'
 
 const props = defineProps<{
   winners: MonthlyWinner[]
@@ -74,7 +74,7 @@ function monthLabel(yearMonth: string): string {
           <div class="month-name">{{ monthLabel(yearMonth) }}</div>
           <template v-if="winnerMap.get(yearMonth)">
             <ClimberAvatar :name="winnerMap.get(yearMonth)!.climber" :size="32" />
-            <div class="winner-name">{{ winnerMap.get(yearMonth)!.climber }}</div>
+            <div class="winner-name">{{ formatClimberName(winnerMap.get(yearMonth)!.climber) }}</div>
             <div class="winner-points">{{ winnerMap.get(yearMonth)!.points }} pts</div>
           </template>
           <div v-else class="no-winner">&mdash;</div>

--- a/src/components/climbing/cookies/CookieHolderBanner.vue
+++ b/src/components/climbing/cookies/CookieHolderBanner.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ClimberAvatar from './ClimberAvatar.vue'
+import { formatClimberName } from '@/utils/Utils'
 import type { LeaderboardEntry } from '@/utils/Cookies'
 
 withDefaults(
@@ -28,7 +29,7 @@ const emit = defineEmits<{
       <ClimberAvatar :name="holder.climber" :size="72" />
       <div class="holder-info">
         <div class="holder-label">{{ label }}</div>
-        <div class="holder-name b">{{ holder.climber }}</div>
+        <div class="holder-name b">{{ formatClimberName(holder.climber) }}</div>
         <div class="holder-total">{{ holder.total }} cookies</div>
       </div>
     </template>

--- a/src/components/climbing/cookies/CookieLeaderboard.vue
+++ b/src/components/climbing/cookies/CookieLeaderboard.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch } from 'vue'
 import DataTable from '@/components/shared/DataTable.vue'
 import ClimberAvatar from './ClimberAvatar.vue'
+import { formatClimberName } from '@/utils/Utils'
 import type { LeaderboardEntry } from '@/utils/Cookies'
 
 const props = defineProps<{
@@ -50,7 +51,7 @@ const sortable = ['climber', 'total', 'sendCount']
         <template #climber="{ row }">
           <div class="climber-cell">
             <ClimberAvatar :name="row.climber" :size="28" />
-            {{ row.climber }}
+            {{ formatClimberName(row.climber) }}
           </div>
         </template>
         <template #total="{ row }">{{ row.total }}</template>

--- a/src/components/climbing/cookies/CookieTimeSeriesChart.vue
+++ b/src/components/climbing/cookies/CookieTimeSeriesChart.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import type { ChartData, ChartOptions } from 'chart.js'
 import LineGraph from '@/components/charts/LineGraph.vue'
-import { getDistinctColor } from '@/utils/Utils'
+import { formatClimberName, getDistinctColor } from '@/utils/Utils'
 import { useClimberManifestStore } from '@/stores/useClimberManifestStore'
 import type { CookieTimeSeriesEntry } from '@/utils/Cookies'
 
@@ -55,7 +55,7 @@ const chartData = computed<ChartData<'line'>>(() => ({
     const color = colorFor(entry.climber)
     return {
       data: entry.points,
-      label: entry.climber,
+      label: formatClimberName(entry.climber),
       borderColor: color,
       backgroundColor: color,
       pointBackgroundColor: color,

--- a/src/stores/useClimberManifestStore.ts
+++ b/src/stores/useClimberManifestStore.ts
@@ -51,6 +51,10 @@ export const useClimberManifestStore = defineStore('climberManifest', () => {
     return allClimbers.value.find((c) => c.userSlug === userSlug)
   }
 
+  function findByUserName(userName: string): ScorecardManifestEntry | undefined {
+    return allClimbers.value.find((c) => c.userName === userName)
+  }
+
   function fetchAll(): Promise<void> {
     if (loaded.value) return Promise.resolve() // singleton cache - no-op on repeat calls
     loading.value = true
@@ -76,6 +80,7 @@ export const useClimberManifestStore = defineStore('climberManifest', () => {
     visibleClimbers,
     sortedClimbers,
     findBySlug,
+    findByUserName,
     fetchAll,
   }
 })

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -305,6 +305,16 @@ export function kebabToCap(str: string): string {
     .join(' ')
 }
 
+// Display-only abbreviation for a climber's full name (e.g. "David Vasko" ->
+// "D Vasko"), reviving a legacy pseudonymization quirk that used to be baked
+// into a hand-maintained alias list. Never use this for grouping/lookup
+// keys - only the raw name is unique/stable across the app.
+export function formatClimberName(name: string): string {
+  const parts = name.trim().split(/\s+/)
+  if (parts.length < 2) return name
+  return `${parts[0]!.charAt(0).toUpperCase()} ${parts.slice(1).join(' ')}`
+}
+
 /*
 Process the RAW JSON from 81.nu into dv format:
 


### PR DESCRIPTION
Two follow-ups to the manifest-driven climber selection: (1) add formatClimberName() and apply it wherever a climber name renders as a standalone label (dropdown, page titles, cookie leaderboard/banner/ calendar/detail modal, chart legend), reviving the abbreviated look ("David Vasko" -> "D Vasko") that used to come from a hand-maintained alias list - the ascent table's Climber column and CSV export are left untouched since they're data, not labels. Only the rendered text changes; every underlying grouping/lookup key (Cookies.ts Maps, ClimberAvatar's color index, climberSendHistory's filter match) still uses the raw name, so nothing downstream breaks.

(2) ClimberAvatar now shows a climber's real manifest.userAvatar photo when they have one (falling back to the existing colored-initials circle for climbers still on 8a.nu's generic default avatar, or if the photo fails to load), reversing an earlier privacy-motivated decision to never use real photos - confirmed with the user first.


Claude-Session: https://claude.ai/code/session_01AhtHA23Y7o79MXpMHqBqFX